### PR TITLE
[cs] Add ECS with short array syntax rule - []

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require": {},
     "require-dev": {
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7",
+        "symplify/easy-coding-standard": "dev-main"
     }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\ValueObject\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $services = $containerConfigurator->services();
+    $services->set(ArraySyntaxFixer::class)
+        ->call('configure', [[
+            'syntax' => 'short',
+        ]]);
+
+    // run and fix, one by one
+    // $containerConfigurator->import(SetList::SPACES);
+    // $containerConfigurator->import(SetList::ARRAY);
+    // $containerConfigurator->import(SetList::DOCBLOCK);
+    // $containerConfigurator->import(SetList::PSR_12);
+};

--- a/src/JSONDB.php
+++ b/src/JSONDB.php
@@ -70,7 +70,7 @@ class JSONDB {
 				$content = json_decode( $content, true );
 			} else {
 				// Empty file. File was just created
-				$content = array();
+				$content = [];
 			}
 		} else {
 			// Read content of JSON file
@@ -179,7 +179,7 @@ class JSONDB {
 		$this->from( $file, 'partial' );
 
 		$first_row =  current( $this->content );
-		$this->content = array();
+		$this->content = [];
 
 		if( ! empty( $first_row ) ) {
 			$unmatched_columns = 0;
@@ -333,7 +333,7 @@ class JSONDB {
 				$this->content = array_values( $this->content );
 			}
 			elseif( empty( $this->where ) && empty( $this->last_indexes ) ) {
-				$this->content = array();
+				$this->content = [];
 			}
 			
 			$return = true;
@@ -355,9 +355,9 @@ class JSONDB {
 	 * @return object $this 
 	 */
 	private function flush_indexes( $flush_where = false ) {
-		$this->last_indexes = array();
+		$this->last_indexes = [];
 		if( $flush_where )
-			$this->where = array();
+			$this->where = [];
 
 		if ( $this->fp && is_resource( $this->fp ) ) {
 			fclose( $this->fp );
@@ -401,7 +401,7 @@ class JSONDB {
 				$row = (array) $row; // Convert first stage to array if object
 				
 				// Check for rows intersecting with the where values.
-				if( array_uintersect_uassoc( $row, $this->where, array($this, "intersect_value_check" ), "strcasecmp" ) /*array_intersect_assoc( $row, $this->where )*/ ) {
+				if( array_uintersect_uassoc( $row, $this->where, [$this, "intersect_value_check" ], "strcasecmp" ) /*array_intersect_assoc( $row, $this->where )*/ ) {
 					$this->last_indexes[] =  $index;
 					return true;
 				}
@@ -433,7 +433,7 @@ class JSONDB {
 
 			
 			//check if the row = where['col'=>'val', 'col2'=>'val2']
-			if(!array_udiff_uassoc($this->where,$row, array($this, "intersect_value_check" ), "strcasecmp" ) ) {
+			if(!array_udiff_uassoc($this->where,$row, [$this, "intersect_value_check" ], "strcasecmp" ) ) {
 				$r[] = $row;
 				// Append also each row array key
 				$this->last_indexes[] = $index;			

--- a/tests/JSONDBTest.php
+++ b/tests/JSONDBTest.php
@@ -37,11 +37,11 @@ class InsertTest extends TestCase {
 			->where( [ 'name' => $name, 'state' => $state, 'age' => $age ], 'AND' )
 			->get();
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Dummy",
 			"state" => "Lagos",
 			"age" => 12
-		));
+		]);
 
 		$this->assertEquals( $name, $user[0]['name'] );
 	}
@@ -80,66 +80,66 @@ class InsertTest extends TestCase {
 	}
 
 	public function testMultiWhere() : void {
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Jajo",
 			"age" => null,
 			"state" => "Lagos"
-		));
+		]);
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Johnny",
 			"age" => 30,
 			"state" => "Ogun"
-		));
+		]);
 
-		$result = $this->db->select( "*" )->from( "users" )->where( array( "age" => null, "name" => "Jajo" ) )->get();
+		$result = $this->db->select( "*" )->from( "users" )->where( [ "age" => null, "name" => "Jajo" ] )->get();
 		$this->assertEquals( 'Jajo', $result[ 0 ][ 'name' ] );
 	}
 
 	public function testAND() : void {
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Jajo",
 			"age" => 50,
 			"state" => "Lagos"
-		));
+		]);
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Johnny",
 			"age" => 50,
 			"state" => "Ogun"
-		));
+		]);
 
-		$result = $this->db->select( "*" )->from( "users" )->where( array( "age" => 50, "name" => "Jajo" ), JSONDB::AND )->get();
+		$result = $this->db->select( "*" )->from( "users" )->where( [ "age" => 50, "name" => "Jajo" ], JSONDB::AND )->get();
 
 		$this->assertEquals( 1, count($result) );
 		$this->assertEquals( "Jajo", $result[0][ 'name' ] );
 	}
 
 	public function testRegexAND() : void {
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Paulo",
 			"age" => 50,
 			"state" => "Algeria"
-		));
+		]);
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Nina",
 			"age" => 50,
 			"state" => "Nigeria"
-		));
+		]);
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Ogwo",
 			"age" => 49,
 			"state" => "Nigeria"
-		));
+		]);
 
 		$result = ($this->db->select( "*" )
 			->from( "users" )
-			->where( array( 
+			->where( [ 
 				"state" => JSONDB::regex( "/ria/" ), 
 				"age" => JSONDB::regex( "/5[0-9]/" ) 
-			), JSONDB::AND )
+			], JSONDB::AND )
 			->get()
 		);
 		
@@ -149,21 +149,21 @@ class InsertTest extends TestCase {
 	}
 
 	public function testRegex() : void {
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Jajo",
 			"age" => 89,
 			"state" => "Abia"
-		));
+		]);
 
-		$this->db->insert( "users", array(
+		$this->db->insert( "users", [
 			"name" => "Mitchell",
 			"age" => 45,
 			"state" => "Zamfara"
-		));
+		]);
 
 		$result = ( $this->db->select("*")
 			->from( "users")
-			->where(array( "state" => JSONDB::regex( "/Zam/" ) ) )
+			->where([ "state" => JSONDB::regex( "/Zam/" ) ] )
 			->get());
 		
 		$this->assertEquals( 'Mitchell', $result[ 0 ][ 'name' ] );

--- a/tests/PerformanceTest.php
+++ b/tests/PerformanceTest.php
@@ -21,10 +21,10 @@ class PerformanceTest extends TestCase {
 			$sum = 0;
 			for ($j = 0; $j < 1000; $j++ ) {
 				$start = hrtime( true );
-				$this->jsondb->insert( 'food', array(
+				$this->jsondb->insert( 'food', [
 					'name' => 'Rice',
 					'class' => 'Carbohydrate',
-				) );
+				] );
 				$stop = hrtime( true );
 				$sum += ( $stop - $start )/1000000;
 			}


### PR DESCRIPTION
This PR adds first coding standard rule, that changes `array()` to `[]`, available since PHP 5.4 :+1: 

The coding standard will be more powerful than this :) this is just to show how it works and what it changes.