### PR TITLE
Fix: Columns must match as of the first row

### DIFF
--- a/src/JSONDB.php
+++ b/src/JSONDB.php
@@ -217,7 +217,7 @@ class JSONDB
             }
 
             foreach ($values as $col => $val) {
-                if (! isset($first_row[$col])) {
+                if (! array_key_exists($col, $first_row)) {
                     $unmatched_columns = 1;
                     break;
                 }


### PR DESCRIPTION
If one of the columns has a null value, the error "Columns must match as of the first row" happens even if the number of columns and its names are the same.
